### PR TITLE
fix&suppress compiling errors

### DIFF
--- a/trac_ik_examples/CMakeLists.txt
+++ b/trac_ik_examples/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Wshadow -Werror)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wshadow)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
+++ b/trac_ik_kinematics/trac_ik_kinematics_plugin/src/trac_ik_kinematics_plugin.cpp
@@ -384,7 +384,7 @@ namespace trac_ik_kinematics_plugin
         solution[z] = out(z);
 
       // check for collisions if a callback is provided
-      if (!solution_callback.empty())
+      if (solution_callback)
       {
         solution_callback(ik_pose, solution, error_code);
         if (error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)


### PR DESCRIPTION
- Fixed the `std::function.empty()` mentioned in https://github.com/aprotyas/trac_ik/pull/34#issuecomment-1564129860

- Supress compiling error on package `trac_ik_examples` by removing `-Werror` comliper flag (not so elegant but at least it works)

  - OS: Ubuntu 22.04 (parallels vm)
  
  - gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
  
  - GNU Make 4.3 (Built for aarch64-unknown-linux-gnu)
  
  - cmake version 3.22.1
  
  - libstdc++-12-dev/jammy-updates,jammy-security,now 12.3.0-1ubuntu1~22.04 arm64

    Error message:

    ```
    --- stderr: trac_ik_examples                                                                                                                                   
    /home/parallels/engineer-2025/src/opi/trac_ik/trac_ik_examples/src/ik_tests.cpp: In function ‘int main(int, char**)’:
    /home/parallels/engineer-2025/src/opi/trac_ik/trac_ik_examples/src/ik_tests.cpp:215:7: error: ‘timeout’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      215 |   test(node, num_samples, chain_start, chain_end, timeout, urdf_xml);
          |   ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /home/parallels/engineer-2025/src/opi/trac_ik/trac_ik_examples/src/ik_tests.cpp:186:7: error: ‘num_samples’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
      186 |   int num_samples;
          |       ^~~~~~~~~~~
    cc1plus: all warnings being treated as errors
    gmake[2]: *** [CMakeFiles/ik_tests.dir/build.make:76: CMakeFiles/ik_tests.dir/src/ik_tests.cpp.o] Error 1
    gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/ik_tests.dir/all] Error 2
    gmake: *** [Makefile:146: all] Error 2
    ---
    Failed   <<< trac_ik_examples [15.4s, exited with code 2]
    ```

    For some reason this won't show up when compiling these trac_ik packages only, but if i put these in a large workspace this error message shows up.

Big thanks for saving my time!! :))